### PR TITLE
Add field to package.json that tells TSC where to find type declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "scrollbar"
   ],
   "main": "./dist/lib/index.js",
+  "types": "./dist/lib/index.d.ts",
   "scripts": {
     "build": "ng build",
     "e2e": "ng e2e",


### PR DESCRIPTION
This is necessary due to the way Typescript resolves declaration files in modules. Essentially, if there isn't a `@types` package found for it in `/node_modules` and there isn't any overrides found in the relevant `tsconfig.json`, then it will look for a field `"types"` in the module's `package.json`.

If it can't find the type declarations, you'll see an error on import if you have `--noImplicitAny`, and in either case TypeScript will fail to pull in the correct types.

Fixes #35 

Relevant documentation:
https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

And a relevant issue:
https://github.com/Microsoft/TypeScript/issues/9854
